### PR TITLE
Persist profile display name on signup

### DIFF
--- a/AuthContext.js
+++ b/AuthContext.js
@@ -61,6 +61,15 @@ export function AuthProvider({ children }) {
         username,
         display_name: username,
       });
+
+      // Immediately store the authenticated user and profile
+      setUser(newUser);
+      setProfile({
+        id: userId,
+        username,
+        display_name: username,
+        email: newUser.email,
+      });
     }
 
     return { error: null };

--- a/app/TopTabsNavigator.tsx
+++ b/app/TopTabsNavigator.tsx
@@ -23,7 +23,7 @@ const Tab = createMaterialTopTabNavigator();
 
 export default function TopTabsNavigator() {
 
-  const { profile } = useAuth() as any;
+  const { profile, user } = useAuth() as any;
 
   const displayName = profile?.display_name || profile?.username;
 


### PR DESCRIPTION
## Summary
- persist user profile after signup so the username is stored immediately
- show the fetched username in the top tabs header

## Testing
- `npm test` *(fails: Missing script 'test')*