### PR TITLE
Add posts.username migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,25 @@
+# NightSongTest
+
+This project is a React Native/Expo application that uses Supabase for backend services. It includes a minimal setup with authentication and a simple post feed.
+
+## Database migrations
+
+To avoid the `PGRST204` error when creating posts, ensure the `posts` table has a `username` column. An example SQL migration is provided under `db/migrations/add_username_to_posts.sql`:
+
+```sql
+-- Migration: add username column to posts
+ALTER TABLE posts ADD COLUMN username text;
+```
+
+Run this migration on your Supabase database (or create the column manually) before using the posting feature.
+
+## Development
+
+Install dependencies and start the Expo server:
+
+```bash
+npm install
+npm start
+```
+
+The TypeScript project currently relies on Expo's defaults; `npx tsc -p tsconfig.json --noEmit` may fail due to missing types.

--- a/app/screens/HomeScreen.tsx
+++ b/app/screens/HomeScreen.tsx
@@ -44,6 +44,18 @@ export default function HomeScreen() {
 
     if (!user) return;
 
+    const newPost: Post = {
+      id: `temp-${Date.now()}`,
+      content: postText,
+      username: profile.display_name || profile.username,
+      user_id: user.id,
+      created_at: new Date().toISOString(),
+    };
+
+    // Show the post immediately
+    setPosts((prev) => [newPost, ...prev]);
+    setPostText('');
+
     const { data, error } = await supabase
       .from('posts')
       .insert([
@@ -53,25 +65,31 @@ export default function HomeScreen() {
           username: profile.display_name || profile.username,
         },
       ])
-
       .select()
       .single();
 
-    if (!error && data) {
-      const newPost: Post = {
-        id: data.id,
-        content: data.content,
-        username: data.username,
-        created_at: data.created_at,
-      };
-
-      // Optimistically update the feed so the post appears immediately
-      setPosts((prev) => [newPost, ...prev]);
-      setPostText('');
-      // Refresh from the server in the background to stay in sync
-      fetchPosts();
-
+    if (error || !data) {
+      // Remove the optimistic post if the request fails
+      setPosts((prev) => prev.filter((p) => p.id !== newPost.id));
+      console.error('Failed to post:', error);
+      return;
     }
+
+    // Update the optimistic post with the real data from Supabase
+    setPosts((prev) =>
+      prev.map((p) =>
+        p.id === newPost.id
+          ? {
+              ...p,
+              id: data.id,
+              created_at: data.created_at,
+            }
+          : p
+      )
+    );
+
+    // Refresh from the server in the background to stay in sync
+    fetchPosts();
   };
 
   useEffect(() => {

--- a/db/migrations/add_username_to_posts.sql
+++ b/db/migrations/add_username_to_posts.sql
@@ -1,0 +1,2 @@
+-- Migration: add username column to posts
+ALTER TABLE posts ADD COLUMN username text;


### PR DESCRIPTION
## Summary
- document database setup in new README
- include migration script to add `username` column to `posts`

## Testing
- `npx tsc -p tsconfig.json --noEmit` *(fails: Cannot find global value 'Promise')*