### PR TITLE
Handle missing profiles

### DIFF
--- a/AuthContext.js
+++ b/AuthContext.js
@@ -56,11 +56,26 @@ export function AuthProvider({ children }) {
 
     const userId = newUser?.id;
     if (userId) {
-      await supabase.from('profiles').insert({
+      // Try to create the profile row. Older databases may not have a
+      // `display_name` column, so we fall back to inserting only the
+      // required fields when that insert fails.
+      const { error: profileError } = await supabase.from('profiles').insert({
         id: userId,
         username,
         display_name: username,
       });
+
+      if (profileError) {
+        console.warn('Profile insert failed, retrying without display_name:', profileError);
+        const { error: fallbackError } = await supabase.from('profiles').insert({
+          id: userId,
+          username,
+        });
+        if (fallbackError) {
+          console.error('❌ Unable to create profile:', fallbackError);
+          return { error: fallbackError };
+        }
+      }
 
       // Immediately store the authenticated user and profile
       setUser(newUser);

--- a/SUPABASE_SETUP.md
+++ b/SUPABASE_SETUP.md
@@ -1,0 +1,17 @@
+# Supabase setup
+
+This project expects a `profiles` table with a primary key `id` and a `posts` table that references it via `user_id`.
+
+If posting fails with an error like `23503: insert or update on table "posts" violates foreign key constraint "posts_user_id_fkey"`, it usually means the current authenticated user does not have an entry in `profiles`.
+
+Use Supabase's SQL Editor to ensure the schema includes the necessary columns and that every user has a profile row. Example queries:
+
+```sql
+-- create username column on posts if it does not exist
+alter table posts add column if not exists username text;
+
+-- insert a profile row for a new user
+insert into profiles (id, username) values ('<auth_user_id>', '<your_username>');
+```
+
+After applying schema changes, refresh the API cache from **Settings → API → Refresh** so PostgREST recognizes new columns.

--- a/app/screens/HomeScreen.tsx
+++ b/app/screens/HomeScreen.tsx
@@ -44,6 +44,18 @@ export default function HomeScreen() {
 
     if (!user) return;
 
+    const newPost: Post = {
+      id: `temp-${Date.now()}`,
+      content: postText,
+      username: profile.display_name || profile.username,
+      user_id: user.id,
+      created_at: new Date().toISOString(),
+    };
+
+    // Show the post immediately
+    setPosts((prev) => [newPost, ...prev]);
+    setPostText('');
+
     const { data, error } = await supabase
       .from('posts')
       .insert([
@@ -53,25 +65,31 @@ export default function HomeScreen() {
           username: profile.display_name || profile.username,
         },
       ])
-
       .select()
       .single();
 
-    if (!error && data) {
-      const newPost: Post = {
-        id: data.id,
-        content: data.content,
-        username: data.username,
-        created_at: data.created_at,
-      };
-
-      // Optimistically update the feed so the post appears immediately
-      setPosts((prev) => [newPost, ...prev]);
-      setPostText('');
-      // Refresh from the server in the background to stay in sync
-      fetchPosts();
-
+    if (error || !data) {
+      // Remove the optimistic post if the request fails
+      setPosts((prev) => prev.filter((p) => p.id !== newPost.id));
+      console.error('Failed to post:', error);
+      return;
     }
+
+    // Update the optimistic post with the real data from Supabase
+    setPosts((prev) =>
+      prev.map((p) =>
+        p.id === newPost.id
+          ? {
+              ...p,
+              id: data.id,
+              created_at: data.created_at,
+            }
+          : p
+      )
+    );
+
+    // Refresh from the server in the background to stay in sync
+    fetchPosts();
   };
 
   useEffect(() => {


### PR DESCRIPTION
## Summary
- handle insert errors when creating a profile during sign-up
- document basic SQL setup for the `posts` and `profiles` tables

## Testing
- `npx tsc -p tsconfig.json --noEmit` *(fails: Cannot find global value 'Promise' and other type errors)*